### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/saguro/rapid/configserver/components/DynamicConfigComponent.java
+++ b/src/main/java/com/saguro/rapid/configserver/components/DynamicConfigComponent.java
@@ -96,6 +96,9 @@ public class DynamicConfigComponent {
             if (application.contains("..") || application.contains("/") || application.contains("\\")) {
                 throw new IllegalArgumentException("Invalid filename");
             }
+            if (profile.contains("..") || profile.contains("/") || profile.contains("\\")) {
+                throw new IllegalArgumentException("Invalid profile name");
+            }
             File tempDir = prepareTemporaryDirectory(label);
             Git git = cloneRepository(appEntity, tempDir, label);
 
@@ -126,16 +129,17 @@ public class DynamicConfigComponent {
     }
 
     private File findConfigFile(File tempDir, String application, String profile) {
+        File controlledDir = tempDir.getAbsoluteFile();
         if (profile.equals("default")) {
             for (String ext : SUPPORTED_EXTENSIONS) {
-                File configFile = new File(tempDir, application + ext);
+                File configFile = new File(controlledDir, application + ext);
                 if (configFile.exists()) {
                     return configFile;
                 }
             }
         } else {
             for (String ext : SUPPORTED_EXTENSIONS) {
-                File configFile = new File(tempDir, application + "-" + profile + ext);
+                File configFile = new File(controlledDir, application + "-" + profile + ext);
                 if (configFile.exists()) {
                     return configFile;
                 }


### PR DESCRIPTION
Potential fix for [https://github.com/samrogu/rapid-config-server/security/code-scanning/10](https://github.com/samrogu/rapid-config-server/security/code-scanning/10)

To fix the issue, we need to validate the `profile` input before it is used to construct file paths. This involves checking for malicious patterns such as `..`, `/`, or `\` in the `profile` string. If any of these patterns are found, the input should be rejected with an appropriate exception.

The validation logic should be added in the `loadConfigFromApplication` method, where the `profile` input is first used. This ensures that tainted data does not propagate further into the application.

Additionally, we should ensure that the `findConfigFile` method only constructs paths within a controlled directory, preventing unintended access to other parts of the file system.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
