### PR TITLE
Potential fix for code scanning alert no. 12: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/saguro/rapid/configserver/config/SecurityConfig.java
+++ b/src/main/java/com/saguro/rapid/configserver/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-            .csrf(csrf -> csrf.disable())
+            .csrf(csrf -> csrf.ignoringRequestMatchers("/api/auth/**")) // Disable CSRF for specific endpoints if necessary
             .cors(cors -> cors.configure(http)); // Asumiendo que tienes config global para CORS
 
         return http.build();


### PR DESCRIPTION
Potential fix for [https://github.com/samrogu/rapid-config-server/security/code-scanning/12](https://github.com/samrogu/rapid-config-server/security/code-scanning/12)

To fix the issue, CSRF protection should be enabled for the `/api/**` endpoints. If there are specific endpoints or use cases where CSRF protection is not required (e.g., for non-browser clients), those exceptions should be explicitly documented and handled. 

The `csrf.disable()` call on line 52 should be replaced with a configuration that enables CSRF protection. If token-based authentication is used, CSRF tokens can be ignored for requests authenticated via tokens. Alternatively, CSRF protection can be enabled with a custom configuration to handle specific cases.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
