### PR TITLE
Potential fix for code scanning alert no. 11: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/saguro/rapid/configserver/config/SecurityConfig.java
+++ b/src/main/java/com/saguro/rapid/configserver/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
             .securityMatcher("/config/**") // Solo para rutas /config
             .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
             .httpBasic(Customizer.withDefaults()) // Basic Auth
-            .csrf(csrf -> csrf.disable());
+            .csrf(Customizer.withDefaults());
 
         return http.build();
     }


### PR DESCRIPTION
Potential fix for [https://github.com/samrogu/rapid-config-server/security/code-scanning/11](https://github.com/samrogu/rapid-config-server/security/code-scanning/11)

To fix the issue, CSRF protection should be enabled for the `/config/**` endpoints. If there are specific endpoints within `/config/**` that require CSRF protection to be disabled (e.g., for non-browser clients), this should be done selectively using `csrf.ignoringRequestMatchers()` instead of disabling CSRF entirely. 

The fix involves:
1. Removing `csrf.disable()` from the `configSecurity` method.
2. Optionally, using `csrf.ignoringRequestMatchers()` to disable CSRF protection for specific endpoints if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
