### PR TITLE
Add container image build configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,3 +77,17 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+bootBuildImage {
+    imageName = System.getenv('IMAGE_NAME') ?: "rapid-config-server:${project.version}"
+    if (System.getenv('REGISTRY_URL')) {
+        publish = true
+        docker {
+            publishRegistry {
+                url = System.getenv('REGISTRY_URL')
+                username = System.getenv('REGISTRY_USERNAME')
+                password = System.getenv('REGISTRY_PASSWORD')
+            }
+        }
+    }
+}
+

--- a/readme.md
+++ b/readme.md
@@ -23,3 +23,24 @@ Expone endpoints para manejar aplicaciones:
 - **GET** `/api/applications/organization/{organizationId}`: Lista las aplicaciones de una organización específica.
 - **POST** `/api/applications/organization/{organizationId}`: Crea una nueva aplicación asociada a una organización.
 - **DELETE** `/api/applications/{id}`: Elimina una aplicación por su ID.
+
+### Imagen de contenedor
+
+Se puede generar una imagen de contenedor nativa con la tarea `bootBuildImage` de Spring Boot.
+
+Variables de entorno útiles:
+
+- `IMAGE_NAME`: nombre completo de la imagen (incluye el repositorio). Por defecto se usa `rapid-config-server:${version}`.
+- `REGISTRY_URL`: URL del registro al que se publicará la imagen.
+- `REGISTRY_USERNAME` y `REGISTRY_PASSWORD`: credenciales para dicho registro.
+
+Ejemplo de ejecución:
+
+```bash
+IMAGE_NAME=tu-registro.com/rapid-config-server:1.0 \
+REGISTRY_URL=tu-registro.com \
+REGISTRY_USERNAME=usuario REGISTRY_PASSWORD=clave \
+./gradlew bootBuildImage
+```
+
+Si se define `REGISTRY_URL`, la tarea publicará la imagen automáticamente en ese repositorio.


### PR DESCRIPTION
## Summary
- add bootBuildImage task configuration with optional publish registry
- document how to build and push the container image using Spring Boot

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684521cdb5e08329a9a40851462650fb