### PR TITLE
Fix security config in controller tests

### DIFF
--- a/src/test/java/com/saguro/rapid/configserver/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/saguro/rapid/configserver/controller/ApplicationControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import com.saguro.rapid.configserver.components.JwtAuthenticationFilter;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -28,6 +29,9 @@ class ApplicationControllerTest {
 
     @MockBean
     private ApplicationService applicationService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Test
     void getAllApplicationsReturnsList() throws Exception {

--- a/src/test/java/com/saguro/rapid/configserver/controller/AuthControllerTest.java
+++ b/src/test/java/com/saguro/rapid/configserver/controller/AuthControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import com.saguro.rapid.configserver.components.JwtAuthenticationFilter;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Set;
@@ -31,6 +32,9 @@ class AuthControllerTest {
 
     @MockBean
     private AuthService authService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Test
     void loginReturnsTokenAndUser() throws Exception {

--- a/src/test/java/com/saguro/rapid/configserver/controller/ConfigControllerTest.java
+++ b/src/test/java/com/saguro/rapid/configserver/controller/ConfigControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import com.saguro.rapid.configserver.components.JwtAuthenticationFilter;
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -22,6 +23,9 @@ class ConfigControllerTest {
 
     @MockBean
     private DynamicConfigComponent dynamicConfigComponent;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Test
     void getConfigReturnsEnvironment() throws Exception {

--- a/src/test/java/com/saguro/rapid/configserver/controller/OrganizationControllerTest.java
+++ b/src/test/java/com/saguro/rapid/configserver/controller/OrganizationControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import com.saguro.rapid.configserver.components.JwtAuthenticationFilter;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -28,6 +29,9 @@ class OrganizationControllerTest {
 
     @MockBean
     private OrganizationService organizationService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Test
     void getAllOrganizationsReturnsList() throws Exception {

--- a/src/test/java/com/saguro/rapid/configserver/controller/RoleControllerTest.java
+++ b/src/test/java/com/saguro/rapid/configserver/controller/RoleControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import com.saguro.rapid.configserver.components.JwtAuthenticationFilter;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -25,6 +26,9 @@ class RoleControllerTest {
 
     @MockBean
     private RoleService roleService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Test
     void getAllRolesReturnsList() throws Exception {

--- a/src/test/java/com/saguro/rapid/configserver/controller/UserControllerTest.java
+++ b/src/test/java/com/saguro/rapid/configserver/controller/UserControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import com.saguro.rapid.configserver.components.JwtAuthenticationFilter;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -28,6 +29,9 @@ class UserControllerTest {
 
     @MockBean
     private UserService userService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Test
     void getAllUsersReturnsList() throws Exception {

--- a/src/test/java/com/saguro/rapid/configserver/controller/UserPermissionControllerTest.java
+++ b/src/test/java/com/saguro/rapid/configserver/controller/UserPermissionControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import com.saguro.rapid.configserver.components.JwtAuthenticationFilter;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -30,6 +31,9 @@ class UserPermissionControllerTest {
 
     @MockBean
     private UserPermissionMapper userPermissionMapper;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Test
     void getPermissionsByUsernameReturnsList() throws Exception {


### PR DESCRIPTION
## Summary
- mock `JwtAuthenticationFilter` in controller tests to satisfy `SecurityConfig`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6845230892f08329909663779e72072b