### PR TITLE
Reduce container image size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,8 @@ tasks.named('test') {
 
 bootBuildImage {
     imageName = System.getenv('IMAGE_NAME') ?: "rapid-config-server:${project.version}"
+    // Builder ligero por defecto para minimizar el tamaño de la imagen
+    builder = System.getenv('BUILDER') ?: "paketobuildpacks/builder-jammy-tiny"
     if (System.getenv('REGISTRY_URL')) {
         publish = true
         docker {

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ Se puede generar una imagen de contenedor nativa con la tarea `bootBuildImage` d
 Variables de entorno útiles:
 
 - `IMAGE_NAME`: nombre completo de la imagen (incluye el repositorio). Por defecto se usa `rapid-config-server:${version}`.
+- `BUILDER`: builder de Paketo a utilizar. Por defecto se emplea `paketobuildpacks/builder-jammy-tiny` para generar una imagen reducida.
 - `REGISTRY_URL`: URL del registro al que se publicará la imagen.
 - `REGISTRY_USERNAME` y `REGISTRY_PASSWORD`: credenciales para dicho registro.
 
@@ -38,6 +39,7 @@ Ejemplo de ejecución:
 
 ```bash
 IMAGE_NAME=tu-registro.com/rapid-config-server:1.0 \
+BUILDER=paketobuildpacks/builder-jammy-tiny \
 REGISTRY_URL=tu-registro.com \
 REGISTRY_USERNAME=usuario REGISTRY_PASSWORD=clave \
 ./gradlew bootBuildImage


### PR DESCRIPTION
## Summary
- default to the lightweight paketo `jammy-tiny` builder when building container images
- document the new `BUILDER` variable for controlling the builder and show in the example

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68452c11908883299f1738c024b17705