### PR TITLE
Fix permission creation 403

### DIFF
--- a/src/main/java/com/saguro/rapid/configserver/config/SecurityConfig.java
+++ b/src/main/java/com/saguro/rapid/configserver/config/SecurityConfig.java
@@ -38,7 +38,9 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-            .csrf(csrf -> csrf.ignoringRequestMatchers("/api/auth/**")) // Disable CSRF for specific endpoints if necessary
+            // CSRF protection is unnecessary for a stateless JWT based API
+            // and was causing 403 responses when no token was provided.
+            .csrf(csrf -> csrf.disable())
             .cors(cors -> cors.configure(http)); // Asumiendo que tienes config global para CORS
 
         return http.build();


### PR DESCRIPTION
## Summary
- disable CSRF for API endpoints to avoid 403 errors with JWT

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6846645c9c4c8329935e4e9f4932e080