### PR TITLE
Configure Logback via environment variables

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,5 +41,5 @@ configjwt:
 
 logging:
   level:
-    root: info
-    com.saguro.rapid.configserver: WARN
+    root: ${LOG_LEVEL_ROOT:info}
+    com.saguro.rapid.configserver: ${LOG_LEVEL_APP:warn}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <!-- Use environment variables with sensible defaults -->
+    <springProperty scope="context" name="LOG_PATTERN" source="LOG_PATTERN" defaultValue="%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"/>
+    <springProperty scope="context" name="LOG_LEVEL_ROOT" source="LOG_LEVEL_ROOT" defaultValue="INFO"/>
+    <springProperty scope="context" name="LOG_LEVEL_APP" source="LOG_LEVEL_APP" defaultValue="DEBUG"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="${LOG_LEVEL_ROOT}">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <logger name="com.saguro.rapid.configserver" level="${LOG_LEVEL_APP}"/>
+</configuration>


### PR DESCRIPTION
## Summary
- add a `logback-spring.xml` with environment variable support for log levels
- make logging levels in `application.yaml` configurable via env vars

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6846717886a08329a23f5bb81561697e