### PR TITLE
Enable native container builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.3'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.graalvm.buildtools.native' version '0.10.2'
 }
 
 group = 'com.saguro'
@@ -82,6 +83,7 @@ bootBuildImage {
     imageName = System.getenv('IMAGE_NAME') ?: "rapid-config-server:${project.version}"
     // Builder ligero por defecto para minimizar el tamaño de la imagen
     builder = System.getenv('BUILDER') ?: "paketobuildpacks/builder-jammy-tiny"
+    environment = [ 'BP_NATIVE_IMAGE': 'true' ]
     if (System.getenv('REGISTRY_URL')) {
         publish = true
         docker {

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,9 @@ Expone endpoints para manejar aplicaciones:
 
 ### Imagen de contenedor
 
-Se puede generar una imagen de contenedor nativa con la tarea `bootBuildImage` de Spring Boot.
+Se puede generar una imagen de contenedor nativa con la tarea `bootBuildImage` de Spring Boot. 
+Para aprovechar la compilación a imagen nativa se ha configurado el plugin `org.graalvm.buildtools.native`. 
+La tarea se ejecuta con `-Pnative`, lo que compila la aplicación como binario y la incluye en la imagen.
 
 Variables de entorno útiles:
 
@@ -42,7 +44,7 @@ IMAGE_NAME=tu-registro.com/rapid-config-server:1.0 \
 BUILDER=paketobuildpacks/builder-jammy-tiny \
 REGISTRY_URL=tu-registro.com \
 REGISTRY_USERNAME=usuario REGISTRY_PASSWORD=clave \
-./gradlew bootBuildImage
+./gradlew bootBuildImage -Pnative
 ```
 
 Si se define `REGISTRY_URL`, la tarea publicará la imagen automáticamente en ese repositorio.


### PR DESCRIPTION
## Summary
- configure GraalVM Native Build Tools
- enable native image generation in bootBuildImage
- document usage of `-Pnative` for bootBuildImage

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6874a33c876883299ea5fc613bfce08e