### PR TITLE
Fix GraalVM native build args

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,11 +92,11 @@ graalvmNative {
             buildArgs.addAll(
                 '--no-fallback',
                 '--initialize-at-build-time=org.slf4j.LoggerFactory,ch.qos.logback,org.hibernate,com.sun.jmx,javax.management',
-                '--initialize-at-build-time=org.apache.sshd.sftp.client.fs.SftpFileSystemProvider',
+                '--initialize-at-build-time=org.apache.sshd',
                 '--initialize-at-run-time=io.netty,org.springframework.data.jpa.repository.support',
                 '-H:+ReportExceptionStackTraces',
                 '-H:+PrintClassInitialization',
-                '--enable-url-protocols=http,https,sftp',
+                '--enable-url-protocols=http,https',
                 '--enable-all-security-services',
                 '-H:+AddAllCharsets',
                 '--allow-incomplete-classpath'


### PR DESCRIPTION
## Summary
- tune GraalVM build args to initialize the Apache sshd package at build time and drop unused SFTP protocol

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68773de2f60c832985d0a67d60a9dab3