### PR TITLE
Refactor UserPermission to JSON permissions

### DIFF
--- a/src/main/java/com/saguro/rapid/configserver/controller/ApplicationController.java
+++ b/src/main/java/com/saguro/rapid/configserver/controller/ApplicationController.java
@@ -41,7 +41,8 @@ public class ApplicationController {
         String current = getCurrentUsername();
         boolean hasRead = userPermissionService.getPermissionsByUsername(current)
                 .stream()
-                .anyMatch(UserPermission::isCanRead);
+                .anyMatch(p -> (p.getApplicationPermission() != null && p.getApplicationPermission().isCanRead()) ||
+                               (p.getOrganizationPermission() != null && p.getOrganizationPermission().isCanRead()));
 
         if (!isAdmin(auth) && !hasRead) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN);

--- a/src/main/java/com/saguro/rapid/configserver/converter/PermissionConverter.java
+++ b/src/main/java/com/saguro/rapid/configserver/converter/PermissionConverter.java
@@ -1,0 +1,40 @@
+package com.saguro.rapid.configserver.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saguro.rapid.configserver.entity.Permission;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * JPA converter to store {@link Permission} objects as JSON strings in the database.
+ */
+@Converter(autoApply = false)
+public class PermissionConverter implements AttributeConverter<Permission, String> {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Permission attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Error serializing Permission", e);
+        }
+    }
+
+    @Override
+    public Permission convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isEmpty()) {
+            return null;
+        }
+        try {
+            return mapper.readValue(dbData, Permission.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Error deserializing Permission", e);
+        }
+    }
+}

--- a/src/main/java/com/saguro/rapid/configserver/dto/PermissionDTO.java
+++ b/src/main/java/com/saguro/rapid/configserver/dto/PermissionDTO.java
@@ -1,0 +1,12 @@
+package com.saguro.rapid.configserver.dto;
+
+import lombok.Data;
+
+@Data
+public class PermissionDTO {
+    private boolean canManage;
+    private boolean canRead;
+    private boolean canCreate;
+    private boolean canUpdate;
+    private boolean canDelete;
+}

--- a/src/main/java/com/saguro/rapid/configserver/dto/UserPermissionDTO.java
+++ b/src/main/java/com/saguro/rapid/configserver/dto/UserPermissionDTO.java
@@ -2,6 +2,13 @@ package com.saguro.rapid.configserver.dto;
 
 import lombok.Data;
 
+/**
+ * Data transfer object that represents the permissions of a user for a
+ * particular organization and application. The boolean permission flags have
+ * been grouped into {@link PermissionDTO} objects that will be serialised as
+ * JSON when persisted or returned via the REST API.
+ */
+
 @Data
 public class UserPermissionDTO {
     private Long id;
@@ -9,8 +16,6 @@ public class UserPermissionDTO {
     private Long organizationId; // ID de la organización
     private Long applicationId; // ID de la aplicación (puede ser null si aplica solo a la organización)
 
-    private boolean canRead;
-    private boolean canCreate;
-    private boolean canUpdate;
-    private boolean canDelete;
+    private PermissionDTO organizationPermission;
+    private PermissionDTO applicationPermission;
 }

--- a/src/main/java/com/saguro/rapid/configserver/entity/Permission.java
+++ b/src/main/java/com/saguro/rapid/configserver/entity/Permission.java
@@ -1,0 +1,16 @@
+package com.saguro.rapid.configserver.entity;
+
+import lombok.Data;
+
+/**
+ * Simple POJO representing a set of permission flags. Instances of this class
+ * are persisted as JSON via {@link com.saguro.rapid.configserver.converter.PermissionConverter}.
+ */
+@Data
+public class Permission {
+    private boolean canManage;
+    private boolean canRead;
+    private boolean canCreate;
+    private boolean canUpdate;
+    private boolean canDelete;
+}

--- a/src/main/java/com/saguro/rapid/configserver/entity/UserPermission.java
+++ b/src/main/java/com/saguro/rapid/configserver/entity/UserPermission.java
@@ -1,7 +1,9 @@
 package com.saguro.rapid.configserver.entity;
 
+import com.saguro.rapid.configserver.converter.PermissionConverter;
 import jakarta.persistence.*;
 import lombok.Data;
+import com.saguro.rapid.configserver.entity.Permission;
 
 @Data
 @Entity
@@ -23,15 +25,11 @@ public class UserPermission {
     @JoinColumn(name = "application_id", nullable = true)
     private Application application;
 
-    @Column(nullable = false)
-    private boolean canRead = false;
+    @Convert(converter = PermissionConverter.class)
+    @Column(columnDefinition = "TEXT")
+    private Permission organizationPermission;
 
-    @Column(nullable = false)
-    private boolean canCreate = false;
-
-    @Column(nullable = false)
-    private boolean canUpdate = false;
-
-    @Column(nullable = false)
-    private boolean canDelete = false;
+    @Convert(converter = PermissionConverter.class)
+    @Column(columnDefinition = "TEXT")
+    private Permission applicationPermission;
 }

--- a/src/main/java/com/saguro/rapid/configserver/mapper/UserPermissionMapper.java
+++ b/src/main/java/com/saguro/rapid/configserver/mapper/UserPermissionMapper.java
@@ -12,18 +12,10 @@ public interface UserPermissionMapper {
     @Mapping(target = "username", source = "user.username")
     @Mapping(target = "organizationId", source = "organization.id")
     @Mapping(target = "applicationId", source = "application.id")
-    @Mapping(target = "canRead", source = "canRead")
-    @Mapping(target = "canCreate", source = "canCreate")
-    @Mapping(target = "canUpdate", source = "canUpdate")
-    @Mapping(target = "canDelete", source = "canDelete")
     UserPermissionDTO toDTO(UserPermission userPermission);
 
     @Mapping(target = "user.username", source = "username")
     @Mapping(target = "organization.id", source = "organizationId")
     @Mapping(target = "application.id", source = "applicationId")
-    @Mapping(target = "canRead", source = "canRead")
-    @Mapping(target = "canCreate", source = "canCreate")
-    @Mapping(target = "canUpdate", source = "canUpdate")
-    @Mapping(target = "canDelete", source = "canDelete")
     UserPermission toEntity(UserPermissionDTO userPermissionDTO);
 }

--- a/src/main/java/com/saguro/rapid/configserver/repository/UserPermissionRepository.java
+++ b/src/main/java/com/saguro/rapid/configserver/repository/UserPermissionRepository.java
@@ -27,16 +27,4 @@ public interface UserPermissionRepository extends JpaRepository<UserPermission, 
     boolean existsByUserUsernameAndOrganizationId(String username, Long organizationId);
 
     boolean existsByUserUsernameAndApplicationId(String username, Long applicationId);
-
-    boolean existsByUserUsernameAndApplicationIdAndCanReadTrue(String username, Long applicationId);
-
-    boolean existsByUserUsernameAndApplicationIdAndCanCreateTrue(String username, Long applicationId);
-
-    boolean existsByUserUsernameAndApplicationIdAndCanUpdateTrue(String username, Long applicationId);
-
-    boolean existsByUserUsernameAndApplicationIdAndCanDeleteTrue(String username, Long applicationId);
-
-    boolean existsByUserUsernameAndOrganizationIdAndCanReadTrue(String username, Long organizationId);
-
-    boolean existsByUserUsernameAndOrganizationIdAndCanCreateTrue(String username, Long organizationId);
 }

--- a/src/test/java/com/saguro/rapid/configserver/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/saguro/rapid/configserver/controller/ApplicationControllerTest.java
@@ -5,6 +5,7 @@ import com.saguro.rapid.configserver.dto.ApplicationDTO;
 import com.saguro.rapid.configserver.service.ApplicationService;
 import com.saguro.rapid.configserver.service.UserPermissionService;
 import com.saguro.rapid.configserver.entity.UserPermission;
+import com.saguro.rapid.configserver.entity.Permission;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -63,7 +64,9 @@ class ApplicationControllerTest {
         when(applicationService.getAllApplications())
             .thenReturn(Collections.singletonList(dto));
         UserPermission perm = new UserPermission();
-        perm.setCanRead(true);
+        Permission appPerm = new Permission();
+        appPerm.setCanRead(true);
+        perm.setApplicationPermission(appPerm);
         when(userPermissionService.getPermissionsByUsername("user"))
             .thenReturn(Collections.singletonList(perm));
 


### PR DESCRIPTION
## Summary
- introduce `PermissionDTO` and `Permission` classes to group boolean flags
- persist permissions as JSON with new `PermissionConverter`
- adapt `UserPermissionDTO` and JPA entity to use organization/application permissions
- update service logic and repository queries
- adjust controllers and unit tests to new structure

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6879f2e1c85c83299709463c80c553ad